### PR TITLE
Add sledgehammer solution to ipv6 problem

### DIFF
--- a/10_resolv.d
+++ b/10_resolv.d
@@ -23,6 +23,9 @@ vpn-up)
 vpn-down)
   $RESOLVCONF -d "${VPN_IP_IFACE}.inet"
   ;;
+up)
+  /usr/bin/sysctl -w net.ipv6.conf.all.disable_ipv6=1
+  ;;
 esac
 
 exit 0


### PR DESCRIPTION
Because NetworkManager is mean and enables ipv6 again, this PR kills ipv6 after literally every connection.